### PR TITLE
Fix: Use next/image for Logo component

### DIFF
--- a/src/components/Common/Logo.tsx
+++ b/src/components/Common/Logo.tsx
@@ -1,17 +1,20 @@
+import Image from 'next/image';
+
 interface LogoProps {
   size?: 'sm' | 'md' | 'lg';
   className?: string;
 }
 
-const heightMap = { sm: 28, md: 36, lg: 56 };
+const sizeMap = { sm: { w: 120, h: 28 }, md: { w: 154, h: 36 }, lg: { w: 240, h: 56 } };
 
 const Logo = ({ size = 'md', className = '' }: LogoProps) => (
-  <img
+  <Image
     src="/logo_full.svg"
     alt="Librarr"
-    height={heightMap[size]}
-    style={{ height: heightMap[size] }}
+    width={sizeMap[size].w}
+    height={sizeMap[size].h}
     className={className}
+    priority
   />
 );
 


### PR DESCRIPTION
## Description
Replace `<img>` with `<Image>` from `next/image` in the Logo component to fix ESLint warning and improve LCP performance.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->