### PR TITLE
Fix Docker image name to lowercase

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Docker Image
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: navino16/librarr
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description
Docker registry requires lowercase image names. `github.repository` returns `Navino16/Librarr` with uppercase, causing the build to fail with `invalid reference format: repository name must be lowercase`.

Hardcode the image name to `navino16/librarr` to fix the issue.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->