### PR TITLE
Use native ARM runner for arm64 Docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,22 +62,20 @@ jobs:
 
   docker:
     name: Build (${{ matrix.platform }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: [lint, test]
     strategy:
       matrix:
         include:
           - platform: linux/amd64
             suffix: amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
             suffix: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        if: matrix.platform == 'linux/arm64'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Description
Replace QEMU emulation with GitHub's native ARM runner (`ubuntu-24.04-arm`) for the arm64 Docker build. QEMU emulation causes 20-30min builds due to slow cross-compilation of native modules (bcrypt, better-sqlite3). Native ARM runner should bring this down to ~3-5min.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->